### PR TITLE
Add OPEN_AI_MODEL env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Add to `.env` file in the `backend` folder.
 - `OPEN_AI_KEY` - OpenAI API key
 - `DATABASE_URL` - PostgreSQL database URL (eg. `postgres://user:password@localhost:5432/database`)
 - `DOCKER_HOST` - Docker SDK API (eg. `DOCKER_HOST=unix:///Users/<my-user>/Library/Containers/com.docker.docker/Data/docker.raw.sock`) [more info](https://stackoverflow.com/a/62757128/5922857)
+Optional:
+- `OPEN_AI_MODEL` - OpenAI model (default: `gpt-4-0125-preview`). The list of supported OpenAI models can be found [here](https://pkg.go.dev/github.com/sashabaranov/go-openai#pkg-constants).
 ### Frontend
 Frontend environment variables can be set by creating a `.env.local` file in the `frontend` folder.
 - `VITE_API_URL` - Backend API URL. *Omit* the URL scheme (e.g., `localhost:8080` *NOT* `http://localhost:8080`).

--- a/backend/agent/agent.go
+++ b/backend/agent/agent.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	openai "github.com/sashabaranov/go-openai"
 	"github.com/semanser/ai-coder/assets"
+	"github.com/semanser/ai-coder/config"
 	"github.com/semanser/ai-coder/database"
 	"github.com/semanser/ai-coder/services"
 	"github.com/semanser/ai-coder/templates"
@@ -126,8 +127,7 @@ func NextTask(args AgentPrompt) (*database.Task, error) {
 
 	req := openai.ChatCompletionRequest{
 		Temperature: 0.0,
-		// TODO make it as an env variable
-		Model: openai.GPT4Turbo0125,
+		Model:       config.Config.OpenAIModel,
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role:    openai.ChatMessageRoleSystem,

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -9,6 +9,7 @@ import (
 
 type config struct {
 	OpenAIKey   string `env:"OPEN_AI_KEY"`
+	OpenAIModel string `env:"OPEN_AI_MODEL" envDefault:"gpt-4-0125-preview"`
 	DatabaseURL string `env:"DATABASE_URL"`
 	Port        int    `env:"PORT" envDefault:"8080"`
 }


### PR DESCRIPTION
`OPEN_AI_MODEL` - OpenAI model (default: `gpt-4-0125-preview`). The list of supported OpenAI models can be found [here](https://pkg.go.dev/github.com/sashabaranov/go-openai#pkg-constants).